### PR TITLE
fixes linux inotify issue

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[server]
+fileWatcherType = "poll"


### PR DESCRIPTION
Streamlit was trying to monitor a lot of files for changes to reload the page. This was leading to issues because the Streamlit server had limitations on the number of files that can be wached. The config being set here stops perpetual checking of files for changes.